### PR TITLE
Update user-update event documentation

### DIFF
--- a/content/docs/(guides)/websocket.mdx
+++ b/content/docs/(guides)/websocket.mdx
@@ -338,7 +338,7 @@ A "`friend-location`" event is sent when one of the user's friends has changed i
 User events are relating to the current user logged in.
 
 #### user-update
-A "`user-update`" event is sent when something regarding the user has been updated. Note that the "`user`" object is **not** a LimitedUser object, even though it has similarities. It's missing `developerType`, `friendKey`, `isFriend`, `last_platform` and `location`. It also has extra `currentAvatar` and `currentAvatarAssetUrl` fields.
+A "`user-update`" event is sent when something regarding the user has been updated. Note that the "`user`" object is **not** a LimitedUser object, even though it has similarities. It's missing `developerType`, `friendKey`, `isFriend`, `last_platform` and `location`. It also has an extra `currentAvatar` field.
 
 ```json
 {
@@ -348,7 +348,6 @@ A "`user-update`" event is sent when something regarding the user has been updat
         "user": {
             "bio": ":bioString",
             "currentAvatar": ":avatarId",
-            "currentAvatarAssetUrl": ":assetUrl",
             "currentAvatarImageUrl": ":assetUrl",
             "currentAvatarThumbnailImageUrl": ":assetUrl",
             "displayName": ":displayName",


### PR DESCRIPTION
Removed 'currentAvatarAssetUrl' field from user-update event documentation.