### PR TITLE
Fix Invalid DOM alerts in openapi.mdx

### DIFF
--- a/content/docs/(guides)/contributing/openapi.mdx
+++ b/content/docs/(guides)/contributing/openapi.mdx
@@ -31,7 +31,7 @@ While it is possible to modify the spec in a normal editor like VSCode, it is st
 
 The following **optional** video goes into better explanation of what OpenAPI is:
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/pRS9LRBgjYg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/pRS9LRBgjYg" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe>
 
 ## 3. Open project
 


### PR DESCRIPTION
```diff
-Invalid DOM property `frameborder`. Did you mean `frameBorder`?
-Invalid DOM property `allowfullscreen`. Did you mean `allowFullScreen`?
```